### PR TITLE
Feature/naming improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,22 @@ Simple wrapper built around Objective-C `@try`/`@catch`/`@finally`.
 
     pod 'SwiftTryCatch'
 
-### Create bridging header (not necessary if using use_frameworks! flag in PodFile)   
+### Import
 
-- When prompted with "Would you like to configure an Obj-C bridging header?", press "Yes".
-- Go to bridging header and add:
+If using Frameworks for pods (use_frameworks! flag in Podfile):
 
-        #import "SwiftTryCatch.h"
+    import SwiftTryCatch
+
+or import into Obj-C bridging header:
+
+    #import "SwiftTryCatch.h"
 
 ### Use
 
-    SwiftTryCatch.tryRun({
+    SwiftTryCatch.try({
              // try something
-         }, catchRun: { (error) in
-             println("\(error.description)")
-         }, finallyRun: {
+         }, catch: { (error) in
+             print("\(error.description)")
+         }, finally: {
              // close resources
     })

--- a/SwiftTryCatch.h
+++ b/SwiftTryCatch.h
@@ -32,7 +32,7 @@
 /**
  Provides try catch functionality for swift by wrapping around Objective-C
  */
-+ (void)tryRun:(void (^)())tryRun catchRun:(void (^)(NSException *))catchRun finallyRun:(void (^)())finallyRun;
++ (void)try:(void (^)())try catch:(void (^)(NSException *))catch finally:(void (^)())finally;
 + (void)throwString:(NSString*)s;
 + (void)throwException:(NSException*)e;
 @end

--- a/SwiftTryCatch.h
+++ b/SwiftTryCatch.h
@@ -27,12 +27,16 @@
 #import <Foundation/Foundation.h>
 @import UIKit;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SwiftTryCatch : NSObject
 
 /**
  Provides try catch functionality for swift by wrapping around Objective-C
  */
-+ (void)try:(void (^)())try catch:(void (^)(NSException *))catch finally:(void (^)())finally;
++ (void)try:(__attribute__((noescape))  void(^ _Nullable)())try catch:(__attribute__((noescape)) void(^ _Nullable)(NSException*exception))catch finally:(__attribute__((noescape)) void(^ _Nullable)())finally;
 + (void)throwString:(NSString*)s;
 + (void)throwException:(NSException*)e;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SwiftTryCatch.m
+++ b/SwiftTryCatch.m
@@ -32,15 +32,15 @@
 /**
  Provides try catch functionality for swift by wrapping around Objective-C
  */
-+(void)tryRun:(void (^)())tryRun catchRun:(void (^)(NSException *))catchRun finallyRun:(void (^)())finallyRun {
++(void)try:(void (^)())try catch:(void (^)(NSException *))catch finally:(void (^)())finally {
     @try {
-        tryRun ? tryRun() : nil;
+        if (try != NULL) try();
     }
     @catch (NSException *exception) {
-        catchRun ? catchRun(exception) : nil;
+        if (catch != NULL) catch(exception);
     }
     @finally {
-        finallyRun ? finallyRun() : nil;
+        if (finally != NULL) finally();
     }
 }
 


### PR DESCRIPTION
This branch also includes the annotations added in this pr https://github.com/williamFalcon/SwiftTryCatch/pull/12

I personally think the try/catch/finally parameter names is nicer than tryRun/catchRun/finallyRun names. Xcode bridges it to swift correctly with backticks, and the keywords are actually allowed to be used this way, see https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html#//apple_ref/doc/uid/TP40014097-CH30-ID413