### PR TITLE
fixed warnings about nullable in xcode13 and swift5

### DIFF
--- a/SwiftTryCatch.h
+++ b/SwiftTryCatch.h
@@ -34,9 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
  Provides try catch functionality for swift by wrapping around Objective-C
  */
 
-+ (void)try:(__attribute__((noescape))  void(^ _Nullable)(void))try catch:(__attribute__((noescape)) void(^ _Nullable)(NSException*exception))catch finally:(__attribute__((noescape)) void(^ _Nullable)(void))finally;
-+ (void)throwString:(NSString*)s;
-+ (void)throwException:(NSException*)e;
++ (void)try:(__attribute__((noescape))  void(^ _Nullable)(void))try catch:(__attribute__((noescape)) void(^ _Nullable)(NSException* _Nullable exception))catch finally:(__attribute__((noescape)) void(^ _Nullable)(void))finally;
++ (void)throwString:(NSString*_Nullable)s;
++ (void)throwException:(NSException*_Nullable)e;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SwiftTryCatch.m
+++ b/SwiftTryCatch.m
@@ -32,7 +32,7 @@
 /**
  Provides try catch functionality for swift by wrapping around Objective-C
  */
-+ (void)try:(__attribute__((noescape))  void(^ _Nullable)(void))try catch:(__attribute__((noescape)) void(^ _Nullable)(NSException*exception))catch finally:(__attribute__((noescape)) void(^ _Nullable)(void))finally {
++ (void)try:(__attribute__((noescape))  void(^ _Nullable)(void))try catch:(__attribute__((noescape)) void(^ _Nullable)(NSException*_Nullable exception))catch finally:(__attribute__((noescape)) void(^ _Nullable)(void))finally {
     @try {
         if (try != NULL) try();
     }
@@ -44,14 +44,14 @@
     }
 }
 
-+ (void)throwString:(NSString*)s
++ (void)throwString:(NSString*_Nullable)s
 {
-	@throw [NSException exceptionWithName:s reason:s userInfo:nil];
+    @throw [NSException exceptionWithName:s reason:s userInfo:nil];
 }
 
-+ (void)throwException:(NSException*)e
++ (void)throwException:(NSException*_Nullable)e
 {
-	@throw e;
+    @throw e;
 }
 
 @end


### PR DESCRIPTION
I added null checks in order to hide warnings and possible issue because of null cases.